### PR TITLE
Show metric descriptions as FormHelperText

### DIFF
--- a/src/components/Filters.js
+++ b/src/components/Filters.js
@@ -141,6 +141,9 @@ const Filters = (props) => {
           ))
         }
         </Select>
+        <FormHelperText>
+          {apiMetrics.filter((metric) => metric?.id === options?.metric)[0]?.description}
+        </FormHelperText>
       </FormControl>
 
       {


### PR DESCRIPTION
Proposed solution for [issue #5 Show metric descriptions](https://github.com/Som-Energia/opendata-ui/issues/5)